### PR TITLE
Fix loading mask after video starts

### DIFF
--- a/smg_fivestar.user.js
+++ b/smg_fivestar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name             收看SMGTV电视节目
 // @namespace        http://tampermonkey.net/
-// @version          0.7
+// @version          0.8
 // @description      打开网页即可收看SMGTV，并解除试看倒计时与切页暂停等限制
 // @author           https://github.com/Popukok
 // @match            *://*.kankanews.com/huikan*
@@ -16,6 +16,10 @@
 (function() {
     'use strict';
     const STYLE_ID = 'smgtv-unlock-style';
+    const VIDEO_READY_CLASS = 'smgtv-video-ready';
+    const VIDEO_READY_EVENTS = ['loadeddata', 'canplay', 'playing', 'timeupdate', 'progress'];
+    const VIDEO_RESET_EVENTS = ['loadstart', 'waiting', 'stalled', 'emptied'];
+    const watchedVideos = new WeakSet();
     function injectStyle(cssText) {
         const appendStyle = () => {
             if (document.getElementById(STYLE_ID)) {
@@ -35,27 +39,128 @@
     function getVueInstance(el) {
         return el?.__vue__ || el?.__vueParentComponent?.proxy || null;
     }
-    function findTVComponent() {
-        const tvEl = document.querySelector('.tv');
-        if (tvEl) {
-            return getVueInstance(tvEl);
-        }
-        const playerBox = document.querySelector('.player-box');
-        if (!playerBox) {
-            return null;
-        }
-        let el = playerBox.parentElement;
-        while (el) {
-            const instance = getVueInstance(el);
-            if (instance && typeof instance.startCountdown === 'function') {
+    function isTVComponent(instance) {
+        return !!instance && (
+            typeof instance.initPlayer === 'function' ||
+            typeof instance.playProgram === 'function' ||
+            typeof instance.setLiveTimer === 'function' ||
+            ('isLoading' in instance && 'player' in instance)
+        );
+    }
+    function findComponentFromElement(el) {
+        let current = el;
+        while (current) {
+            const instance = getVueInstance(current);
+            if (isTVComponent(instance)) {
                 return instance;
             }
-            el = el.parentElement;
+            current = current.parentElement;
         }
         return null;
     }
+    function findTVComponent() {
+        const selectors = ['.huikan', '.live-container', '.live-box', '.live-player', '.tv', '.player-box'];
+        for (const selector of selectors) {
+            const component = findComponentFromElement(document.querySelector(selector));
+            if (component) {
+                return component;
+            }
+        }
+        return null;
+    }
+    function getPlayerVideo(component) {
+        const player = component?.player;
+        return player?.video ||
+            player?.media ||
+            player?.root?.querySelector?.('video') ||
+            component?.$refs?.livePlayer?.querySelector?.('video') ||
+            document.querySelector('.live-player video, .player-box video, .xgplayer video, video');
+    }
+    function isVideoReady(video) {
+        return !!video && !video.error && (
+            video.readyState >= 2 ||
+            (!video.paused && video.currentTime > 0)
+        );
+    }
+    function setVideoReadyClass(isReady) {
+        const target = document.body || document.documentElement;
+        target?.classList?.toggle(VIDEO_READY_CLASS, isReady);
+    }
+    function syncLoadingState(component) {
+        const video = getPlayerVideo(component);
+        if (video) {
+            watchPlayerVideo(component, video);
+        }
+        const isReady = isVideoReady(video);
+        setVideoReadyClass(isReady);
+        if (isReady && component && component.isLoading) {
+            component.isLoading = false;
+            console.log('[SMGTV] 已同步播放器 loading 状态');
+        }
+        return isReady;
+    }
+    function watchPlayerVideo(component, video) {
+        if (!video || watchedVideos.has(video)) {
+            return;
+        }
+        watchedVideos.add(video);
+        const markReady = () => syncLoadingState(component);
+        const resetReady = () => {
+            if (!isVideoReady(video)) {
+                setVideoReadyClass(false);
+            }
+        };
+        VIDEO_READY_EVENTS.forEach(eventName => {
+            video.addEventListener(eventName, markReady, { passive: true });
+        });
+        VIDEO_RESET_EVENTS.forEach(eventName => {
+            video.addEventListener(eventName, resetReady, { passive: true });
+        });
+        markReady();
+    }
+    function startLoadingMonitor(component) {
+        if (!component || component.__smgLoadingMonitor) {
+            return;
+        }
+        component.__smgLoadingMonitor = setInterval(() => syncLoadingState(component), 500);
+        if (component.$refs?.livePlayer && !component.__smgLoadingObserver) {
+            component.__smgLoadingObserver = new MutationObserver(() => syncLoadingState(component));
+            component.__smgLoadingObserver.observe(component.$refs.livePlayer, {
+                childList: true,
+                subtree: true
+            });
+        }
+    }
+    function wrapComponentMethod(component, methodName, after) {
+        const original = component?.[methodName];
+        if (typeof original !== 'function' || original.__smgWrapped) {
+            return;
+        }
+        const wrapped = function() {
+            const result = original.apply(this, arguments);
+            const runAfter = () => {
+                setTimeout(() => after(this), 0);
+                setTimeout(() => after(this), 250);
+                setTimeout(() => after(this), 1000);
+            };
+            if (result && typeof result.then === 'function') {
+                result.then(runAfter, runAfter);
+            } else {
+                runAfter();
+            }
+            return result;
+        };
+        wrapped.__smgWrapped = true;
+        wrapped.__smgOriginal = original;
+        component[methodName] = wrapped;
+    }
     function patchComponent(component) {
-        if (!component || component.__smgPatched) {
+        if (!component) {
+            return;
+        }
+        startLoadingMonitor(component);
+        if (component.__smgPatched) {
+            syncLoadingState(component);
             return;
         }
         component.__smgPatched = true;
@@ -86,6 +191,10 @@
             window.removeEventListener('unload', component._handlerUnload);
             component._handlerUnload = null;
         }
+        ['initPlayer', 'initNoProgramPlayer', 'initPadPlayer', 'changeProgram', 'changeChannel'].forEach(methodName => {
+            wrapComponentMethod(component, methodName, syncLoadingState);
+        });
+        syncLoadingState(component);
         console.log('[SMGTV] 页面限制补丁已生效');
     }
     function initComponentPatch() {
@@ -107,16 +216,28 @@
     }
     injectStyle(`
     .video-tip {
-    display: none !important;
+        display: none !important;
+    }
+    body.${VIDEO_READY_CLASS} .loading-mask {
+        display: none !important;
+        pointer-events: none !important;
     }
     `);
     
     // 保存原始的XMLHttpRequest.open方法
     const originalOpen = XMLHttpRequest.prototype.open;
     // 重写XMLHttpRequest.open方法
+    function isTargetTVApi(url) {
+        try {
+            return new URL(String(url), location.href).pathname.includes('/content/pc/tv/');
+        } catch (e) {
+            return String(url).includes('/content/pc/tv/');
+        }
+    }
     XMLHttpRequest.prototype.open = function(method, url) {
+        const requestUrl = String(url);
         // 检查是否是目标API请求
-        if (url.includes('https://kapi.kankanews.com/content/pc/tv/')) {
+        if (isTargetTVApi(requestUrl)) {
             // 监听readystatechange事件
             this.addEventListener('readystatechange', function() {
                 if (this.readyState === 4 && this.status === 200) {
@@ -126,13 +247,14 @@
                         let modified = false;
 
                         // 处理单个节目详情接口
-                        if (url.includes('/program/detail') && response.result) {
+                        if (requestUrl.includes('/program/detail') && response.result) {
                             response.result.is_shield = 0;
                             response.result.is_review = 1;
+                            response.result.can_review = 1;
                             modified = true;
                         }
                         // 处理节目列表接口
-                        if (url.includes('/programs') && response.result?.programs) {
+                        if (requestUrl.includes('/programs') && response.result?.programs) {
                             response.result.programs.forEach(program => {
                                 program.is_shield = 0;
                                 program.is_review = 1;


### PR DESCRIPTION
## Summary

您好，感谢维护这个脚本。我在使用时遇到一个小问题：播放器实际已经可以正常播放，切换到其他 tab 后浏览器自动弹出的小窗里也能看到画面，但页面上的 `loading-mask` 仍然一直显示，导致看起来像播放器还在加载。

我查了一下当前看看新闻页面的逻辑，页面主要依赖 xgplayer 的 `canplay` 事件把 Vue 组件里的 `isLoading` 设为 `false`。在 HLS、自动播放、或者切换 tab 触发小窗播放的场景下，视频可能已经出画，但 loading 状态没有被同步清掉。

这个 PR 尝试补一个更稳妥的 loading 状态同步逻辑，不改变原有解除试看和切页暂停限制的核心思路。

另外，测试时也发现全屏按钮在部分情况下点击后没有明显效果。页面当前把 `cssFullscreen` 控件 ignore 掉了，主要依赖 xgplayer 的原生 fullscreen handler。这个 PR 也补了一个较保守的兜底：点击全屏按钮时优先走 xgplayer / 浏览器原生 Fullscreen API，如果失败，再切到 CSS 全屏；再次点击或按 Escape 可以退出 CSS 全屏。

## Changes

- 兼容当前页面的 `.huikan` / `.live-player` DOM 结构来查找播放器组件
- 监听 native video 的 `loadeddata`、`canplay`、`playing`、`timeupdate`、`progress` 等事件
- 通过 `video.readyState >= 2` 或已有播放进度兜底判断视频是否已经可显示
- 视频已经 ready 时同步关闭 Vue 组件的 `isLoading`
- 加了一层 CSS 兜底：视频 ready 后隐藏 `.loading-mask`
- 给 `.xgplayer-fullscreen` 增加点击兜底，原生全屏失败时启用 CSS 全屏
- 将电视节目接口匹配从固定绝对 URL 放宽为 `/content/pc/tv/` 路径匹配，以兼容当前页面的相对 API 路径

## Verification

- `node --check smg_fivestar.user.js`
- 本地 smoke test 验证 userscript 可以正常加载
- 本地 smoke test 验证 `/content/pc/tv/program/detail` 响应仍能正确改写 `is_shield` / `is_review` / `can_review`
- 本地 smoke test 模拟全屏按钮点击，并验证原生全屏不可用时会进入 CSS 全屏兜底

如果这里的处理方式不符合您对脚本维护方向的预期，也欢迎直接指出，我可以按您的建议调整。
