### PR TITLE
Fix fullscreen control fallback

### DIFF
--- a/smg_fivestar.user.js
+++ b/smg_fivestar.user.js
@@ -17,9 +17,14 @@
     'use strict';
     const STYLE_ID = 'smgtv-unlock-style';
     const VIDEO_READY_CLASS = 'smgtv-video-ready';
+    const FULLSCREEN_FALLBACK_CLASS = 'smgtv-fallback-fullscreen';
+    const FULLSCREEN_TARGET_CLASS = 'smgtv-fallback-fullscreen-target';
+    const FULLSCREEN_BUTTON_SELECTOR = '.xgplayer-fullscreen';
     const VIDEO_READY_EVENTS = ['loadeddata', 'canplay', 'playing', 'timeupdate', 'progress'];
     const VIDEO_RESET_EVENTS = ['loadstart', 'waiting', 'stalled', 'emptied'];
     const watchedVideos = new WeakSet();
+    let fullscreenFallbackTarget = null;
+    let lastFullscreenActionAt = 0;
     function injectStyle(cssText) {
         const appendStyle = () => {
             if (document.getElementById(STYLE_ID)) {
@@ -131,6 +136,171 @@
             });
         }
     }
+    function getBrowserFullscreenElement() {
+        return document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.mozFullScreenElement ||
+            document.msFullscreenElement ||
+            null;
+    }
+    function requestElementFullscreen(el) {
+        if (!el) {
+            return Promise.reject(new Error('missing fullscreen target'));
+        }
+        const request =
+            el.requestFullscreen ||
+            el.webkitRequestFullscreen ||
+            el.webkitRequestFullScreen ||
+            el.mozRequestFullScreen ||
+            el.msRequestFullscreen;
+        if (!request) {
+            return Promise.reject(new Error('fullscreen api unavailable'));
+        }
+        try {
+            const result = request.call(el);
+            return result && typeof result.then === 'function' ? result : Promise.resolve();
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+    function exitBrowserFullscreen() {
+        const exit =
+            document.exitFullscreen ||
+            document.webkitExitFullscreen ||
+            document.webkitCancelFullScreen ||
+            document.mozCancelFullScreen ||
+            document.msExitFullscreen;
+        if (!exit) {
+            return Promise.resolve();
+        }
+        try {
+            const result = exit.call(document);
+            return result && typeof result.then === 'function' ? result : Promise.resolve();
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+    function getFullscreenTarget(component, button) {
+        return component?.player?.root ||
+            button?.closest?.('.xgplayer') ||
+            component?.$refs?.livePlayer?.querySelector?.('.xgplayer') ||
+            component?.$refs?.livePlayer ||
+            document.querySelector('.live-player .xgplayer, .player-box .xgplayer, .xgplayer, .live-player, .player-box');
+    }
+    function syncFullscreenButtonState(component, isFullscreen) {
+        const player = component?.player;
+        if (player) {
+            player.fullscreen = !!isFullscreen;
+        }
+        document.querySelectorAll(FULLSCREEN_BUTTON_SELECTOR).forEach(button => {
+            button.setAttribute('data-state', isFullscreen ? 'full' : 'normal');
+        });
+    }
+    function enterFallbackFullscreen(target, component) {
+        if (!target) {
+            return;
+        }
+        exitFallbackFullscreen(component);
+        fullscreenFallbackTarget = target;
+        target.classList.add(FULLSCREEN_TARGET_CLASS);
+        document.body?.classList.add(FULLSCREEN_FALLBACK_CLASS);
+        syncFullscreenButtonState(component, true);
+        console.log('[SMGTV] 已启用 CSS 全屏兜底');
+    }
+    function exitFallbackFullscreen(component) {
+        if (fullscreenFallbackTarget) {
+            fullscreenFallbackTarget.classList.remove(FULLSCREEN_TARGET_CLASS);
+            fullscreenFallbackTarget = null;
+        }
+        document.body?.classList.remove(FULLSCREEN_FALLBACK_CLASS);
+        syncFullscreenButtonState(component, false);
+    }
+    function isFallbackFullscreen() {
+        return !!document.body?.classList.contains(FULLSCREEN_FALLBACK_CLASS);
+    }
+    function callFullscreenMethod(fn) {
+        try {
+            const result = fn();
+            return result && typeof result.then === 'function' ? result : Promise.resolve();
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+    function enterFullscreen(component, target) {
+        const player = component?.player;
+        const enterNative = callFullscreenMethod(() => (
+            player && typeof player.getFullscreen === 'function' ?
+                player.getFullscreen(target) :
+                requestElementFullscreen(target)
+        ));
+        Promise.resolve(enterNative)
+            .then(() => syncFullscreenButtonState(component, true))
+            .catch(() => enterFallbackFullscreen(target, component));
+    }
+    function exitFullscreen(component) {
+        const player = component?.player;
+        if (isFallbackFullscreen()) {
+            exitFallbackFullscreen(component);
+            return;
+        }
+        const exitNative = callFullscreenMethod(() => (
+            player && typeof player.exitFullscreen === 'function' ?
+                player.exitFullscreen() :
+                exitBrowserFullscreen()
+        ));
+        Promise.resolve(exitNative)
+            .catch(exitBrowserFullscreen)
+            .then(
+                () => syncFullscreenButtonState(component, false),
+                () => syncFullscreenButtonState(component, false)
+            );
+    }
+    function handleFullscreenControl(event) {
+        const button = event.target?.closest?.(FULLSCREEN_BUTTON_SELECTOR);
+        if (!button) {
+            return;
+        }
+        const now = Date.now();
+        if (now - lastFullscreenActionAt < 300) {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation?.();
+            return;
+        }
+        lastFullscreenActionAt = now;
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation?.();
+        const component = findTVComponent();
+        const target = getFullscreenTarget(component, button);
+        syncLoadingState(component);
+        if (getBrowserFullscreenElement() || isFallbackFullscreen()) {
+            exitFullscreen(component);
+        } else {
+            enterFullscreen(component, target);
+        }
+    }
+    function handleFullscreenChange() {
+        if (getBrowserFullscreenElement()) {
+            exitFallbackFullscreen(findTVComponent());
+            syncFullscreenButtonState(findTVComponent(), true);
+        } else if (!isFallbackFullscreen()) {
+            syncFullscreenButtonState(findTVComponent(), false);
+        }
+    }
+    function initFullscreenPatch() {
+        document.addEventListener('click', handleFullscreenControl, true);
+        document.addEventListener('touchend', handleFullscreenControl, true);
+        document.addEventListener('fullscreenchange', handleFullscreenChange);
+        document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
+        document.addEventListener('mozfullscreenchange', handleFullscreenChange);
+        document.addEventListener('MSFullscreenChange', handleFullscreenChange);
+        document.addEventListener('keydown', event => {
+            if (event.key === 'Escape' && isFallbackFullscreen()) {
+                exitFallbackFullscreen(findTVComponent());
+            }
+        });
+    }
     function wrapComponentMethod(component, methodName, after) {
         const original = component?.[methodName];
         if (typeof original !== 'function' || original.__smgWrapped) {
@@ -222,6 +392,24 @@
         display: none !important;
         pointer-events: none !important;
     }
+    body.${FULLSCREEN_FALLBACK_CLASS} {
+        overflow: hidden !important;
+    }
+    .${FULLSCREEN_TARGET_CLASS} {
+        background: #000 !important;
+        height: 100vh !important;
+        inset: 0 !important;
+        max-height: none !important;
+        max-width: none !important;
+        position: fixed !important;
+        width: 100vw !important;
+        z-index: 2147483647 !important;
+    }
+    .${FULLSCREEN_TARGET_CLASS} video {
+        height: 100% !important;
+        object-fit: contain !important;
+        width: 100% !important;
+    }
     `);
     
     // 保存原始的XMLHttpRequest.open方法
@@ -285,4 +473,5 @@
     } else {
         window.addEventListener('load', initComponentPatch, { once: true });
     }
+    initFullscreenPatch();
 })();

--- a/smg_fivestar.user.js
+++ b/smg_fivestar.user.js
@@ -24,6 +24,7 @@
     const VIDEO_RESET_EVENTS = ['loadstart', 'waiting', 'stalled', 'emptied'];
     const watchedVideos = new WeakSet();
     let fullscreenFallbackTarget = null;
+    let cssFullscreenFallbackPlayer = null;
     let lastFullscreenActionAt = 0;
     function injectStyle(cssText) {
         const appendStyle = () => {
@@ -200,6 +201,18 @@
         if (!target) {
             return;
         }
+        const player = component?.player;
+        if (player && typeof player.getCssFullscreen === 'function') {
+            try {
+                player.getCssFullscreen(target);
+                cssFullscreenFallbackPlayer = player;
+                syncFullscreenButtonState(component, true);
+                console.log('[SMGTV] 已启用 xgplayer CSS 全屏兜底');
+                return;
+            } catch (e) {
+                console.warn('[SMGTV] xgplayer CSS 全屏失败，使用样式兜底', e);
+            }
+        }
         exitFallbackFullscreen(component);
         fullscreenFallbackTarget = target;
         target.classList.add(FULLSCREEN_TARGET_CLASS);
@@ -208,6 +221,15 @@
         console.log('[SMGTV] 已启用 CSS 全屏兜底');
     }
     function exitFallbackFullscreen(component) {
+        const player = component?.player || cssFullscreenFallbackPlayer;
+        if (cssFullscreenFallbackPlayer && player && typeof player.exitCssFullscreen === 'function') {
+            try {
+                player.exitCssFullscreen();
+            } catch (e) {
+                console.warn('[SMGTV] 退出 xgplayer CSS 全屏失败', e);
+            }
+        }
+        cssFullscreenFallbackPlayer = null;
         if (fullscreenFallbackTarget) {
             fullscreenFallbackTarget.classList.remove(FULLSCREEN_TARGET_CLASS);
             fullscreenFallbackTarget = null;
@@ -216,7 +238,9 @@
         syncFullscreenButtonState(component, false);
     }
     function isFallbackFullscreen() {
-        return !!document.body?.classList.contains(FULLSCREEN_FALLBACK_CLASS);
+        return !!document.body?.classList.contains(FULLSCREEN_FALLBACK_CLASS) ||
+            !!cssFullscreenFallbackPlayer?.cssfullscreen ||
+            !!cssFullscreenFallbackPlayer?.isCssfullScreen;
     }
     function callFullscreenMethod(fn) {
         try {
@@ -397,18 +421,61 @@
     }
     .${FULLSCREEN_TARGET_CLASS} {
         background: #000 !important;
+        box-sizing: border-box !important;
         height: 100vh !important;
         inset: 0 !important;
+        margin: 0 !important;
         max-height: none !important;
         max-width: none !important;
+        min-height: 100vh !important;
+        min-width: 100vw !important;
+        padding: 0 !important;
         position: fixed !important;
+        transform: none !important;
         width: 100vw !important;
         z-index: 2147483647 !important;
     }
-    .${FULLSCREEN_TARGET_CLASS} video {
+    .${FULLSCREEN_TARGET_CLASS}.xgplayer,
+    .${FULLSCREEN_TARGET_CLASS} .xgplayer {
         height: 100% !important;
-        object-fit: contain !important;
+        inset: 0 !important;
+        margin: 0 !important;
+        max-height: none !important;
+        max-width: none !important;
+        padding: 0 !important;
+        padding-top: 0 !important;
+        position: absolute !important;
+        transform: none !important;
         width: 100% !important;
+    }
+    .${FULLSCREEN_TARGET_CLASS} .xgplayer-screen-container,
+    .${FULLSCREEN_TARGET_CLASS} xg-video-container.xg-video-container,
+    .${FULLSCREEN_TARGET_CLASS} .xg-video-container {
+        bottom: 0 !important;
+        display: block !important;
+        height: 100% !important;
+        inset: 0 !important;
+        position: absolute !important;
+        width: 100% !important;
+    }
+    .${FULLSCREEN_TARGET_CLASS} video,
+    .${FULLSCREEN_TARGET_CLASS} canvas,
+    .${FULLSCREEN_TARGET_CLASS} live-video {
+        bottom: 0 !important;
+        height: 100% !important;
+        left: 0 !important;
+        max-height: none !important;
+        max-width: none !important;
+        object-fit: contain !important;
+        position: absolute !important;
+        right: 0 !important;
+        top: 0 !important;
+        transform: none !important;
+        width: 100% !important;
+    }
+    .${FULLSCREEN_TARGET_CLASS} .xgplayer-controls,
+    .${FULLSCREEN_TARGET_CLASS} .xg-top-bar {
+        z-index: 2147483647 !important;
     }
     `);
     


### PR DESCRIPTION
## Summary

您好，感谢这么快合并上一个 loading 修复。

我继续测试时发现另一个小问题：播放器控制栏里的全屏按钮在部分情况下点击后没有明显效果。当前页面的播放器配置会 ignore `cssFullscreen` 控件，主要依赖 xgplayer 的原生 fullscreen handler；如果浏览器原生 Fullscreen API 没有成功进入全屏，xgplayer 会静默 catch 掉失败，因此用户侧看起来就是按钮不生效。

这个 PR 补一个较保守的兜底逻辑：点击 `.xgplayer-fullscreen` 时优先使用 xgplayer / 浏览器原生 Fullscreen API；如果失败，再切到 xgplayer 自带的 CSS 全屏。再次点击全屏按钮或按 Escape 会退出 CSS 全屏。

后续测试时发现单纯给播放器根节点 fixed 定位会被 xgplayer 的 `fluid` inline 样式影响，画面可能被挤到底部。因此这里优先使用 xgplayer 自带的 `getCssFullscreen()`，并在最后的自定义样式兜底中清理 `padding-top`，同时覆盖 video / canvas / live-video 和内部容器的定位。

## Changes

- 接管 `.xgplayer-fullscreen` 的点击 / touchend 事件，避免原 handler 静默失败后没有反馈
- 优先调用 xgplayer 的 `getFullscreen` / `exitFullscreen`
- 原生全屏失败时，优先调用 xgplayer 自带的 `getCssFullscreen()`
- 自定义兜底会清理 xgplayer `fluid` 布局的 `padding-top`
- CSS 全屏下保持黑色背景、固定全窗口尺寸，并让 video / canvas / live-video `object-fit: contain`
- 支持再次点击全屏按钮或按 Escape 退出 CSS 全屏

## Verification

- `node --check smg_fivestar.user.js`
- `git diff --check origin/main..HEAD`
- 本地 smoke test 验证 userscript 可以正常加载
- 本地 smoke test 模拟全屏按钮点击，并验证原生全屏不可用时会进入 CSS 全屏兜底
- 本地 smoke test 验证存在 xgplayer 实例时会优先调用 `getCssFullscreen()`

如果您希望这里不要接管全屏按钮，而是改成恢复 xgplayer 的 `cssFullscreen` 控件，也可以告诉我，我可以按您的偏好调整。
